### PR TITLE
Use environment variable as WAR/EAR file name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .settings
 target/
 work/
+.idea/
+*.iml

--- a/src/main/resources/org/jenkinsci/plugins/wildfly/WildflyBuilder/help-war.html
+++ b/src/main/resources/org/jenkinsci/plugins/wildfly/WildflyBuilder/help-war.html
@@ -1,3 +1,4 @@
 <div>
-A single WAR or EAR file to deploy, packaged with the appropriate bindings (if applicable).  Relative to the workspace root.
+A single WAR or EAR file to deploy, packaged with the appropriate bindings (if applicable).  Relative to the workspace root.<br/>
+Environment variables may be used in the tag name - they will be replaced at build time.
 </div>


### PR DESCRIPTION
Hi Dan

In our Jenkins workflow, we are using "Deploy to Wildfly" as downstream project from build project. This makes war/ear filename change (update) with every build from upstream project. 
So we needed to use environment variable as war/ear filename.

This works only if you want to deploy single file. I didn't adjust code for multiple files, because frankly we don't need that :)

Also, only war/ear filename is checking if it is set as environment variable, other parameters like server, port, username, password are still "static". Again, didn't spend time on it, because we don't need it (for now). 

This update works in our production environment, we installed plugin as custom plugin (with hpi file), but it would be nice if you can include this update and publish new version (we would like to use official stuff ;) )

P.S. I'm not really Java developer or Jenkins plugin developer (I did this by looking at your code and a little bit of googling), so I maybe (probably) missed to update some property/version/description somewhere
